### PR TITLE
add find_package with xxxConfig.cmake

### DIFF
--- a/cmake/SalomeMacros.cmake
+++ b/cmake/SalomeMacros.cmake
@@ -449,6 +449,9 @@ MACRO(SALOME_FIND_PACKAGE englobPkg stdPkg mode)
       ELSE()
         FIND_PACKAGE(${stdPkg} ${${englobPkg}_FIND_VERSION} ${_tmp_exact} 
               MODULE ${_tmp_quiet} ${_tmp_req})
+        IF(NOT ${stdPkg}_FOUND)
+          FIND_PACKAGE(${stdPkg} CONFIG)
+        ENDIF()
       ENDIF()
       
     ELSE()


### PR DESCRIPTION
when i use cmake construct salome-gui,i have  installed OpenCASCADE, the 'find_package' ,this cmd should  use the XXXconfig.cmake file instead of the findXXX.cmake file. So i modify the cmake code ,It's becoming more general, and you might be able to make better changes.